### PR TITLE
Přidat MDT šablonu ADR pro nástroj ŠAblonář

### DIFF
--- a/architektonicka_dokumentace/mdt-sablona-adr.mdt
+++ b/architektonicka_dokumentace/mdt-sablona-adr.mdt
@@ -1,0 +1,60 @@
+[[[text: Organizace]]]
+
+
+# Záznam o architektonickém rozhodnutí (ADR): [[[text: Název rozhodnutí]]]
+
+
+## [[[text: Název rozhodnutí]]]
+
+* Stav: [[[volba: návrh, navrženo, schváleno, zamítnuto, nahrazeno, zastaralé]]]
+* Rozhoduje: [[[text: Rozhoduje]]]
+* Účastníci: [[[text: Účastníci]]]
+* Datum aktualizace: [[[datum: Datum aktualizace|j. F Y]]]
+
+[[[text: Stručný popis]]]
+
+### Kontext a popis problému
+
+[[[textarea: Kontext a popis problému]]]
+
+### Motivace a ovlivnění rozhodnutí
+
+[[[odrážky: Motivace a ovlivnění rozhodnutí]]]
+
+### Zvažované možnosti
+
+[[[odrážky: Zvažované možnosti]]]
+
+### Výsledek rozhodnutí
+
+Bylo rozhodnuto dne [[[datum: Datum rozhodnutí|j. F Y]]], rozhodl [[[text: Rozhoduje]]].
+
+Zvolená možnost: [[[text: Zvolená možnost]]]
+
+Zdůvodnění:
+
+[[[odrážky: Zdůvodnění]]]
+
+### Přínosy a dopady a důsledky
+
+Přínosy a pozitivní důsledky
+
+[[[odrážky: Přínosy a pozitivní důsledky]]]
+
+Dopady a negativní důsledky
+
+[[[odrážky: Dopady a negativní důsledky]]]
+
+### Realizace vybrané varianty
+
+Rámcový postup pro realizaci:
+
+[[[odrážky: Rámcový postup pro realizaci]]]
+
+### Odkazy a další informace
+
+[[[textarea: Odkazy a další informace]]]
+
+<!-- markdownlint-disable-file MD013 MD041 -->
+
+<!-- Používá šablonu ADR z adresy https://github.com/egdilna/sablony/blob/main/architektonicka_dokumentace/mdt-sablona-adr.mdt -->


### PR DESCRIPTION
Vytvořena verze šablony architektonického rozhodnutí (`sablona-adr`) ve formátu `.mdt` s placeholdery nástroje ŠAblonář, podle vzoru existující `mdt-sablona-sebehodnoceni-ais-soulad-gp.mdt`.

## Změny

- Nový soubor `architektonicka_dokumentace/mdt-sablona-adr.mdt`

## Použité placeholdery

- `[[[text: …]]]` — jednořádková pole (Organizace, Název rozhodnutí, Rozhoduje, Zvolená možnost…)
- `[[[volba: návrh, navrženo, schváleno, zamítnuto, nahrazeno, zastaralé]]]` — výběr stavu rozhodnutí
- `[[[datum: …|j. F Y]]]` — data (aktualizace, rozhodnutí)
- `[[[odrážky: …]]]` — odrážkové seznamy (motivace, zvažované možnosti, zdůvodnění, přínosy, dopady, postup realizace)
- `[[[textarea: …]]]` — víceřádkové texty (kontext, odkazy)

Stejně pojmenovaná pole (`Organizace`, `Název rozhodnutí`, `Rozhoduje`) se v dokumentu propisují automaticky na všech místech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VApiLtP5EFtHRZ9dstHxmV)_